### PR TITLE
添加全局转换实体属性名方法

### DIFF
--- a/FreeSql/Internal/StringConvertType.cs
+++ b/FreeSql/Internal/StringConvertType.cs
@@ -1,0 +1,45 @@
+﻿namespace FreeSql.Internal
+{
+    public enum StringConvertType
+    {
+        /// <summary>
+        /// 不进行任何处理
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// 将帕斯卡命名字符串转换为下划线分隔字符串
+        /// <para></para>
+        /// BigApple -> Big_Apple
+        /// </summary>
+        PascalCaseToUnderscore,
+
+        /// <summary>
+        /// 将帕斯卡命名字符串转换为下划线分隔字符串，且转换为全大写
+        /// <para></para>
+        /// BigApple -> BIG_APPLE
+        /// </summary>
+        PascalCaseToUnderscoreWithUpper,
+
+        /// <summary>
+        /// 将帕斯卡命名字符串转换为下划线分隔字符串，且转换为全小写
+        /// <para></para>
+        /// BigApple -> big_apple
+        /// </summary>
+        PascalCaseToUnderscoreWithLower,
+
+        /// <summary>
+        /// 将字符串转换为大写
+        /// <para></para>
+        /// BigApple -> BIGAPPLE
+        /// </summary>
+        Upper,
+
+        /// <summary>
+        /// 将字符串转换为小写
+        /// <para></para>
+        /// BigApple -> bigapple
+        /// </summary>
+        Lower
+    }
+}

--- a/FreeSql/Internal/StringUtils.cs
+++ b/FreeSql/Internal/StringUtils.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq;
+
+namespace FreeSql.Internal
+{
+    public static class StringUtils
+    {
+        /// <summary>
+        /// 将帕斯卡命名字符串转换为下划线分隔字符串
+        /// <para></para>
+        /// BigApple -> Big_Apple
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        public static string PascalCaseToUnderScore(string str)
+        {
+            return string.Concat(str.Select((x, i) =>
+                i > 0 && char.IsUpper(x) ? "_" + x.ToString() : x.ToString()));
+        }
+    }
+}


### PR DESCRIPTION
用法

````csharp
new FreeSql.FreeSqlBuilder()
        .UseEntityPropertyNameConvert(StringConvertType.PascalCaseToUnderscore)
	.Build());
````
现在添加了6种转换类型

````csharp
public enum StringConvertType
{
    /// <summary>
    /// 不进行任何处理
    /// </summary>
    None = 0,

    /// <summary>
    /// 将帕斯卡命名字符串转换为下划线分隔字符串
    /// <para></para>
    /// BigApple -> Big_Apple
    /// </summary>
    PascalCaseToUnderscore,

    /// <summary>
    /// 将帕斯卡命名字符串转换为下划线分隔字符串，且转换为全大写
    /// <para></para>
    /// BigApple -> BIG_APPLE
    /// </summary>
    PascalCaseToUnderscoreWithUpper,

    /// <summary>
    /// 将帕斯卡命名字符串转换为下划线分隔字符串，且转换为全小写
    /// <para></para>
    /// BigApple -> big_apple
    /// </summary>
    PascalCaseToUnderscoreWithLower,

    /// <summary>
    /// 将字符串转换为大写
    /// <para></para>
    /// BigApple -> BIGAPPLE
    /// </summary>
    Upper,

    /// <summary>
    /// 将字符串转换为小写
    /// <para></para>
    /// BigApple -> bigapple
    /// </summary>
    Lower
}
````

注意：
- 只会转换属性名，不会转换类名
- 如果属性设置 [Column] 特性且设置了Name，那么该转换方法将不会覆盖这个值
